### PR TITLE
More VS compilation fixes

### DIFF
--- a/config/src/win/config.h
+++ b/config/src/win/config.h
@@ -39,7 +39,7 @@
 #define HAVE_INT8_T 1
 
 /* Define to 1 if you have the <inttypes.h> header file. */
-//#define HAVE_INTTYPES_H 1
+#define HAVE_INTTYPES_H 1
 
 /* Define to 1 if you have the `z' library (-lz). */
 #define HAVE_LIBZ 1
@@ -81,7 +81,7 @@
 /* #undef HAVE_STRICMP */
 
 /* Define to 1 if you have the <strings.h> header file. */
-#define HAVE_STRINGS_H 1
+//#define HAVE_STRINGS_H 1
 
 /* Define to 1 if you have the <string.h> header file. */
 #define HAVE_STRING_H 1
@@ -116,7 +116,7 @@
 #define HAVE_UINT8_T 1
 
 /* Define to 1 if you have the <unistd.h> header file. */
-#define HAVE_UNISTD_H 1
+//#define HAVE_UNISTD_H 1
 
 /* Define to 1 or 0, depending whether the compiler supports simple visibility
    declarations. */

--- a/libzip-1.1.3/lib/compat.h
+++ b/libzip-1.1.3/lib/compat.h
@@ -38,6 +38,10 @@
 #include "config.h"
 #endif
 
+#ifdef HAVE_INTTYPES_H
+#include <inttypes.h>
+#endif
+
 /* to have *_MAX definitions for all types when compiling with g++ */
 #define __STDC_LIMIT_MACROS
 

--- a/libzip-1.1.3/lib/zip_name_locate.c
+++ b/libzip-1.1.3/lib/zip_name_locate.c
@@ -64,7 +64,11 @@ _zip_name_locate(zip_t *za, const char *fname, zip_flags_t flags, zip_error_t *e
 
     if (flags & (ZIP_FL_NOCASE|ZIP_FL_NODIR|ZIP_FL_ENC_CP437)) {
 	/* can't use hash table */
+#ifndef HAVE_STRCASECMP
+	cmp = (flags & ZIP_FL_NOCASE) ? stricmp : strcmp;
+#else
 	cmp = (flags & ZIP_FL_NOCASE) ? strcasecmp : strcmp;
+#endif
 
 	for (i=0; i<za->nentry; i++) {
 	    fn = _zip_get_name(za, i, flags, error);


### PR DESCRIPTION
Fix def causing unistd.h to be included elsewhere.
Use stricmp instead of strcasecmp.
Include <inttypes.h> in compat so the format strings aren't redefined.